### PR TITLE
Add package license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@leonardo-ai/sdk",
   "version": "4.21.3",
   "author": "leonardoai",
+  "license": "MIT",
   "main": "./index.js",
   "sideEffects": false,
   "repository": {


### PR DESCRIPTION
## Summary
- add the MIT license field to the npm package manifest
- align package metadata with the repository LICENSE file

## Verification
- npm pack --dry-run --ignore-scripts --json
- node package manifest assertion